### PR TITLE
Fix Makefile extension in aggregator

### DIFF
--- a/PromptPrep/aggregator.py
+++ b/PromptPrep/aggregator.py
@@ -133,7 +133,7 @@ class CodeAggregator:
         ".md",
         ".rst",
         # Build & Make Systems
-        ".Makefile",
+        "Makefile",
         ".gradle",
         ".cmake",
         ".ninja",


### PR DESCRIPTION
## Summary
- treat Makefile properly in the default extension list

## Testing
- `black PromptPrep/aggregator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eeb6d17dc8324acf82be1b68d694e